### PR TITLE
[MSVC build fix] Wrap __attribute__ (format (...)) in a macro for compatibility with MSVC

### DIFF
--- a/src/my_file.hpp
+++ b/src/my_file.hpp
@@ -8,6 +8,8 @@
 
 #include <stdint.h>
 
+#include "my_format_str_attribute.hpp"
+
 int            file_write(const char *filename, unsigned char *buffer, int len);
 uint8_t        file_exists(const char *filename);
 int            file_size(const char *filename);
@@ -25,7 +27,7 @@ unsigned char *file_load(const char *filename, int *outlen);
 #define SET_BINARY_MODE(file)
 #endif
 
-void FILE_LOG(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
-void FILE_DBG(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+void FILE_LOG(const char *fmt, ...) CHECK_FORMAT_STR(printf, 1, 2);
+void FILE_DBG(const char *fmt, ...) CHECK_FORMAT_STR(printf, 1, 2);
 
 #endif

--- a/src/my_format_str_attribute.hpp
+++ b/src/my_format_str_attribute.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#ifndef _MY_FORMAT_STR_ATTRIBUTE_HPP_
+#define _MY_FORMAT_STR_ATTRIBUTE_HPP_
+
+#if defined(__GNUC__) || defined(__clang__)
+#define CHECK_FORMAT_STR(a, b, c) __attribute__ ((format (a, b, c)))
+#else
+#define CHECK_FORMAT_STR(a, b, c)
+#endif
+
+#endif // _MY_FORMAT_STR_ATTRIBUTE_HPP_

--- a/src/my_level.hpp
+++ b/src/my_level.hpp
@@ -13,6 +13,7 @@
 
 #include "my_dmap.hpp"
 #include "my_fcolor.hpp"
+#include "my_format_str_attribute.hpp"
 #include "my_fwd.hpp"
 #include "my_game_defs.hpp"
 #include "my_laser.hpp"
@@ -899,7 +900,7 @@ public:
   void assign_leaders_and_followers(void);
   void chances_of_creating_set(void);
   void clear(void);
-  void con(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void con(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
   void con_(const char *fmt, va_list args); // compile error without
   void create_biome_dungeon_place_braziers(Dungeonp d, const std::string &what);
   void create_biome_dungeon_place_bridge(Dungeonp d);
@@ -978,7 +979,7 @@ public:
   void display_target(void);
   void display_tick_animation(void);
   void dmap_to_player_update(void);
-  void err(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void err(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
   void err_(const char *fmt, va_list args); // compile error without
   void fade_in_incr(const int x, const int y);
   void fade_in_no_check_incr(const int x, const int y);
@@ -1146,7 +1147,7 @@ public:
   void lights_render_small_lights(int minx, int miny, int maxx, int maxy, int fbo, bool include_player_lights);
   void lights_update_new_level(void);
   void lights_update_same_level(void);
-  void log(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void log(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
   void log_(const char *fmt, va_list args); // compile error without
   void l_shaped_path_to_diag(std::vector< point > &path);
   void new_external_particle(ThingId, point, point, isize, uint32_t dur, Tilep, bool, MyCallback = NoCallback);

--- a/src/my_light.hpp
+++ b/src/my_light.hpp
@@ -6,6 +6,7 @@
 #ifndef _MY_LIGHT_H
 #define _MY_LIGHT_H
 
+#include "my_format_str_attribute.hpp"
 #include "my_fwd.hpp"
 #include "my_point.hpp"
 #include "my_thing_defs.hpp"
@@ -53,22 +54,22 @@ public:
   std::array< std::vector< RayPoint >, LIGHT_MAX_RAYS > points;
 
   bool calculate(void);
-  void con(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void con(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
   void con_(const char *fmt, va_list args); // compile error without
   void destroy();
   void destroyed(void);
-  void die(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void die(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
   void die_(const char *fmt, va_list args); // compile error without
   void draw_line(const int16_t index, const point p0, const point p1);
   void draw_pixel(const int16_t index, const point p0, const point p1);
-  void err(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void err(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
   void err_(const char *fmt, va_list args); // compile error without
-  void log(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void log(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
   void log_(const char *fmt, va_list args); // compile error without
   void render(int ray_cast_only);
   void render_triangle_fans(void);
   void reset(void);
-  void topcon(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void topcon(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
   void topcon_(const char *fmt, va_list args); // compile error without
   void update(void);
 };

--- a/src/my_main.hpp
+++ b/src/my_main.hpp
@@ -6,19 +6,20 @@
 #ifndef _MY_MAIN_HPP_
 #define _MY_MAIN_HPP_
 
+#include "my_format_str_attribute.hpp"
 #include "my_globals.hpp"
 
-void BOTCON(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+void BOTCON(const char *fmt, ...) CHECK_FORMAT_STR(printf, 1, 2);
 void BOTCON(const wchar_t *fmt, ...);
-void CON(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+void CON(const char *fmt, ...) CHECK_FORMAT_STR(printf, 1, 2);
 void CON(const wchar_t *fmt, ...);
-void GAME_UI_MSG_BOX(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
-void LOG(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
-void LOG_MISSING(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
-void TOPCON(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+void GAME_UI_MSG_BOX(const char *fmt, ...) CHECK_FORMAT_STR(printf, 1, 2);
+void LOG(const char *fmt, ...) CHECK_FORMAT_STR(printf, 1, 2);
+void LOG_MISSING(const char *fmt, ...) CHECK_FORMAT_STR(printf, 1, 2);
+void TOPCON(const char *fmt, ...) CHECK_FORMAT_STR(printf, 1, 2);
 void TOPCON(const wchar_t *fmt, ...);
-void SDL_MSG_BOX(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
-void WARN(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+void SDL_MSG_BOX(const char *fmt, ...) CHECK_FORMAT_STR(printf, 1, 2);
+void WARN(const char *fmt, ...) CHECK_FORMAT_STR(printf, 1, 2);
 
 void botcon(const wchar_t *fmt);
 void con(const wchar_t *fmt);
@@ -26,7 +27,7 @@ void ctrlc_handler(int sig);
 void die(void);
 void log_catchup_missing_indent_levels(void);
 void topcon(const wchar_t *fmt);
-void myerr(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+void myerr(const char *fmt, ...) CHECK_FORMAT_STR(printf, 1, 2);
 void quit(void);
 void restart(void);
 void segv_handler(int sig);

--- a/src/my_python.hpp
+++ b/src/my_python.hpp
@@ -11,6 +11,8 @@
 #include <string>
 #include <vector>
 
+#include "my_format_str_attribute.hpp"
+
 PyObject *con_(PyObject *obj, PyObject *args, PyObject *keywds);
 PyObject *die_(PyObject *obj, PyObject *args, PyObject *keywds);
 PyObject *err_(PyObject *obj, PyObject *args, PyObject *keywds);
@@ -272,8 +274,8 @@ std::vector< std::string > py_call_std_vector_string_fn(const char *module, cons
 #name, pysdl_##name, METH_VARARGS, name##_doc                                                                    \
   }
 
-void PY_LOG(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
-void PY_DBG(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+void PY_LOG(const char *fmt, ...) CHECK_FORMAT_STR(printf, 1, 2);
+void PY_DBG(const char *fmt, ...) CHECK_FORMAT_STR(printf, 1, 2);
 
 extern PyObject *my_mod;
 #endif

--- a/src/my_sprintf.hpp
+++ b/src/my_sprintf.hpp
@@ -6,8 +6,10 @@
 #ifndef _MY_SPRINTF_HPP_
 #define _MY_SPRINTF_HPP_
 
+#include "my_format_str_attribute.hpp"
+
 #include <string>
 
-std::string string_sprintf(const char *format, ...) __attribute__((format(printf, 1, 2)));
+std::string string_sprintf(const char *format, ...) CHECK_FORMAT_STR(printf, 1, 2);
 std::string string_sprintf(const char *format, va_list args);
 #endif

--- a/src/my_string.hpp
+++ b/src/my_string.hpp
@@ -13,6 +13,8 @@
 #include <vector>
 #include <wchar.h>
 
+#include "my_format_str_attribute.hpp"
+
 using shared_vector_string  = std::shared_ptr< std::vector< std::string > >;
 using shared_vector_wstring = std::shared_ptr< std::vector< std::wstring > >;
 
@@ -27,7 +29,7 @@ extern size_t strlcat_(char *dst, const char *src, size_t size);
 #define MAXSTR      1024
 #define MAXSHORTSTR 128
 
-char *dynprintf(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+char *dynprintf(const char *fmt, ...) CHECK_FORMAT_STR(printf, 1, 2);
 char *dynvprintf(const char *fmt, va_list args);
 char *strappend(const char *in, const char *append);
 char *strcasestr_(const char *s, const char *find);

--- a/src/my_sys.hpp
+++ b/src/my_sys.hpp
@@ -6,6 +6,8 @@
 #ifndef _MY_SYS_HPP_
 #define _MY_SYS_HPP_
 
+#include "my_format_str_attribute.hpp"
+
 #include <stdint.h>
 
 #if __GNUC__ >= 8
@@ -151,9 +153,9 @@ typedef unsigned long int uint64_t;
 //
 #include "my_callstack.hpp"
 
-void DYING(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
-void CROAK(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
-void CROAK_CLEAN(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+void DYING(const char *fmt, ...) CHECK_FORMAT_STR(printf, 1, 2);
+void CROAK(const char *fmt, ...) CHECK_FORMAT_STR(printf, 1, 2);
+void CROAK_CLEAN(const char *fmt, ...) CHECK_FORMAT_STR(printf, 1, 2);
 
 #define DIE(args...)                                                                                                 \
   DYING("Died at %s:%s():%u", __FILE__, __FUNCTION__, __LINE__);                                                     \

--- a/src/my_thing.hpp
+++ b/src/my_thing.hpp
@@ -12,6 +12,7 @@
 
 #include "my_color.hpp"
 #include "my_dice.hpp"
+#include "my_format_str_attribute.hpp"
 #include "my_fwd.hpp"
 #include "my_point.hpp"
 #include "my_point3d.hpp"
@@ -2235,7 +2236,7 @@ public:
   void blit_wall_shadow(point tl, point br, const ThingTiles *tiles);
   void block_of_ice_tick(void);
   void born_set(point3d);
-  void botcon(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void botcon(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
   void botcon_(const char *fmt, va_list args); // compile error without
   void bounce_count_set(int);
   void bounce_fade_set(float);
@@ -2258,18 +2259,18 @@ public:
   void clear_interrupt_map(void);
   void clear_move_path(const std::string &why);
   void clear_seen_map(void);
-  void con(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void con(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
   void con_(const char *fmt, va_list args); // compile error without
   void corrode_tick(void);
   void cursor_hover_over_check(void);
-  void dbg_(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
-  void dead(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void dbg_(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
+  void dead(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
   void dead_(const char *fmt, va_list args); // compile error without
   void dead(const std::string &);
   void dead_reason_set(const std::string &);
-  void dead_scheduled(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void dead_scheduled(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
   void dead_scheduled(const std::string &);
-  void dead(Thingp defeater, const char *fmt, ...) __attribute__((format(printf, 3, 4)));
+  void dead(Thingp defeater, const char *fmt, ...) CHECK_FORMAT_STR(printf, 3, 4);
   void dead_(Thingp defeater, const char *fmt, va_list args);
   void dead(Thingp defeater, std::string &);
   void debuff_activate(Thingp what);
@@ -2284,7 +2285,7 @@ public:
   void destroy_minions(Thingp defeater);
   void destroy_spawned(Thingp defeater);
   void destroy(void);
-  void die(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void die(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
   void die_(const char *fmt, va_list args); // compile error without
   void dir_set_bl(void);
   void dir_set_br(void);
@@ -2307,7 +2308,7 @@ public:
   void equip_use_anim_id_set(ThingId gfx_anim_use_id, int equip);
   void equip_use_anim_set(Thingp gfx_anim_use, int equip);
   void equip_use_offset_get(int *dx, int *dy, int equip);
-  void err(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void err(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
   void err_(const char *fmt, va_list args); // compile error without
   void fadeup_fade_set(float);
   void fadeup(float fadeup_height, float fadeup_fade, ts_t ms);
@@ -2347,7 +2348,7 @@ public:
   void light_dist_including_torch_effect_get(uint8_t &light_dist);
   void location_check_me(void);
   void location_check(Thingp filter_to = nullptr);
-  void log(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void log(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
   void log_(const char *fmt, va_list args); // compile error without
   void lunge(point tt);
   void lunge_to_set(point);
@@ -2366,7 +2367,7 @@ public:
   void move_speed_curr_set(int);
   void move_to_immediately(point to);
   void move_to(point to);
-  void msg(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void msg(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
   void msg_set(const std::string &);
   void necrosis_tick(void);
   void new_aip(void);
@@ -2458,7 +2459,7 @@ public:
   void throw_at(Thingp w, Thingp target);
   void tick(void);
   void tiles_get(void);
-  void topcon(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void topcon(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
   void topcon_(const char *fmt, va_list args); // compile error without
   void try_to_carry(const std::list< Thingp > &items);
   void unleash_minions(void);

--- a/src/my_thing_template.hpp
+++ b/src/my_thing_template.hpp
@@ -7,6 +7,7 @@
 #define _MY_THING_TEMPLATE_H
 
 #include "my_dice.hpp"
+#include "my_format_str_attribute.hpp"
 #include "my_fwd.hpp"
 #include "my_size.hpp"
 #include "my_thing_defs.hpp"
@@ -818,16 +819,16 @@ public:
   bool is_edible(const Thingp it);
   bool has_temperature(void);
 
-  void dbg_(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
-  void err(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void dbg_(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
+  void err(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
   void err_(const char *fmt, va_list args); // compile error without
-  void log(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void log(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
   void log_(const char *fmt, va_list args); // compile error without
-  void topcon(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void topcon(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
   void topcon_(const char *fmt, va_list args); // compile error without
-  void die(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void die(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
   void die_(const char *fmt, va_list args); // compile error without
-  void con(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void con(const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
   void con_(const char *fmt, va_list args); // compile error without
 
   const Dice &damage_acid_dice(void) const;

--- a/src/my_wid.hpp
+++ b/src/my_wid.hpp
@@ -16,8 +16,8 @@
 #include "my_time.hpp"
 #include "my_wid_tiles.hpp"
 
-void WID_LOG(Widp, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
-void WID_DBG(Widp, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+void WID_LOG(Widp, const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
+void WID_DBG(Widp, const char *fmt, ...) CHECK_FORMAT_STR(printf, 2, 3);
 
 typedef enum {
   WID_COLOR_BG,

--- a/src/ptrcheck.cpp
+++ b/src/ptrcheck.cpp
@@ -124,7 +124,7 @@ static void error_(const char *fmt, va_list args)
   std::cerr << err << std::endl;
 }
 
-void ERROR(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+void ERROR(const char *fmt, ...) CHECK_FORMAT_STR(printf, 1, 2);
 void ERROR(const char *fmt, ...)
 {
   va_list args;


### PR DESCRIPTION
I'm recently trying to compile the game on Windows with MSVC, and ran into a lot of problems. One of the problems is the use of GCC-specific `__attribute__ ((format (printf, 2, 3)))`. In this pull request, I defined a macro `CHECK_FORMAT_STR` that expands to format attribute if compiler is GCC or Clang, and expands to nothing on MSVC, so the code can compile on MSVC.