### PR TITLE
[MSVC build fix] use std::source_location instead of non-portable __PRETTY_FUNCTION__

### DIFF
--- a/src/my_callstack.hpp
+++ b/src/my_callstack.hpp
@@ -6,14 +6,15 @@
 #define _MY_CALLSTACK_HPP_
 
 #include "my_globals.hpp"
+#include "my_source_loc.hpp"
 #include "my_sys.hpp"
 
 #define CAT(A, B)  A##B
 #define CAT2(A, B) CAT(A, B)
 
 #ifdef ENABLE_DEBUG_TRACE
-#define TRACE_AND_INDENT() tracer_t CAT2(__my_trace__, __LINE__)(__PRETTY_FUNCTION__, __LINE__);
-#define TRACE_NO_INDENT()  tracer_no_indent_t CAT2(__my_trace__, __LINE__)(__PRETTY_FUNCTION__, __LINE__);
+#define TRACE_AND_INDENT() tracer_t CAT2(__my_trace__, __LINE__)(SRC_FUNC_NAME, SRC_LINE_NUM);
+#define TRACE_NO_INDENT()  tracer_no_indent_t CAT2(__my_trace__, __LINE__)(SRC_FUNC_NAME, SRC_LINE_NUM);
 #else
 #define TRACE_AND_INDENT()
 #define TRACE_NO_INDENT()

--- a/src/my_gl.hpp
+++ b/src/my_gl.hpp
@@ -8,7 +8,7 @@
 #define GL_GLEXT_PROTOTYPES
 
 #include "my_game_defs.hpp"
-
+#include "my_source_loc.hpp"
 #include <array>
 
 /* Defined before OpenGL and GLUT includes to avoid deprecation messages */
@@ -333,9 +333,9 @@ void glcolorfast(color s);
   {                                                                                                                  \
     auto errCode = glGetError();                                                                                     \
     if (likely(errCode == GL_NO_ERROR)) {                                                                            \
-      /* CON("GFX: ok at %s:%s line %u", __FILE__, __PRETTY_FUNCTION__, __LINE__); */                                \
+      /* CON("GFX: ok at %s:%s line %u", SRC_FILE_NAME, SRC_FUNC_NAME, SRC_LINE_NUM); */                             \
     } else {                                                                                                         \
-      ERR("GFX: error at %s:%s line %u", __FILE__, __PRETTY_FUNCTION__, __LINE__);                                   \
+      ERR("GFX: error at %s:%s line %u", SRC_FILE_NAME, SRC_FUNC_NAME, SRC_LINE_NUM);                                \
       gl_error(errCode);                                                                                             \
     }                                                                                                                \
   }

--- a/src/my_ptrcheck.hpp
+++ b/src/my_ptrcheck.hpp
@@ -3,11 +3,13 @@
 #ifndef _MY__PTRCHECK_HPP__
 #define _MY__PTRCHECK_HPP__
 
+#include "my_source_loc.hpp"
+
 //
 // __FUNCTION__ is not a preprocessor directive so we can't convert it into a
 // string
 //
-#define PTRCHECK_AT __FILE__, __PRETTY_FUNCTION__, __LINE__
+#define PTRCHECK_AT SRC_FILE_NAME, SRC_FUNC_NAME, SRC_LINE_NUM
 
 void *myzalloc_(int size, const char *what, const char *func, const char *file, int line);
 void *mymalloc_(int size, const char *what, const char *func, const char *file, int line);
@@ -56,7 +58,7 @@ void  ptrcheck_leak_print(void);
   {                                                                                                                  \
     if (DEBUG2) {                                                                                                    \
       TRACE_AND_INDENT();                                                                                            \
-      ptrcheck_verify(__mtype__, __ptr__, __FILE__, __PRETTY_FUNCTION__, __LINE__);                                  \
+      ptrcheck_verify(__mtype__, __ptr__, SRC_FILE_NAME, SRC_FUNC_NAME, SRC_LINE_NUM);                               \
     }                                                                                                                \
   }
 

--- a/src/my_source_loc.hpp
+++ b/src/my_source_loc.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#ifndef _MY_SOURCE_LOC_HPP_
+#define _MY_SOURCE_LOC_HPP_
+
+#include <source_location>
+
+#define SRC_FILE_NAME (std::source_location::current().file_name())
+#define SRC_FUNC_NAME (std::source_location::current().function_name())
+#define SRC_LINE_NUM  (std::source_location::current().line())
+
+#endif // _MY_SOURCE_LOC_HPP_

--- a/src/my_sys.hpp
+++ b/src/my_sys.hpp
@@ -7,6 +7,7 @@
 #define _MY_SYS_HPP_
 
 #include "my_format_str_attribute.hpp"
+#include "my_source_loc.hpp"
 
 #include <stdint.h>
 
@@ -157,14 +158,14 @@ void DYING(const char *fmt, ...) CHECK_FORMAT_STR(printf, 1, 2);
 void CROAK(const char *fmt, ...) CHECK_FORMAT_STR(printf, 1, 2);
 void CROAK_CLEAN(const char *fmt, ...) CHECK_FORMAT_STR(printf, 1, 2);
 
-#define DIE(args...)                                                                                                 \
-  DYING("Died at %s:%s():%u", __FILE__, __FUNCTION__, __LINE__);                                                     \
-  CROAK(args);                                                                                                       \
+#define DIE(...)                                                                                                 \
+  DYING("Died at %s:%s():%u", SRC_FILE_NAME, SRC_FUNC_NAME, SRC_LINE_NUM);                                       \
+  CROAK(__VA_ARGS__);                                                                                            \
   exit(1);
 
-#define DIE_CLEAN(args...)                                                                                           \
-  DYING("Exiting at %s:%s():%u", __FILE__, __FUNCTION__, __LINE__);                                                  \
-  CROAK_CLEAN(args);                                                                                                 \
+#define DIE_CLEAN(...)                                                                                           \
+  DYING("Exiting at %s:%s():%u", SRC_FILE_NAME, SRC_FUNC_NAME, SRC_LINE_NUM);                                    \
+  CROAK_CLEAN(__VA_ARGS__);                                                                                      \
   exit(1);
 
 #ifdef DEBUG
@@ -193,15 +194,14 @@ void CROAK_CLEAN(const char *fmt, ...) CHECK_FORMAT_STR(printf, 1, 2);
 // Based on
 // https://stackoverflow.com/questions/2193544/how-to-print-additional-information-when-assert-fails
 #ifdef ENABLE_ASSERT
-#define ASSERT_EX(left, operator, right)                                                                                               \
-  if (! ((left) operator(right))) {                                                                                                    \
-    TRACE_AND_INDENT();                                                                                                                \
-    std::cerr << "ASSERT FAILED: " << #left << " "                                                                                     \
-              << #                                                                                                                     \
-        operator<< " " << #right << " @ " << __FILE__ << ":" << __PRETTY_FUNCTION__ << " line " << __LINE__ << " " << #left << "=" <<( \
-            left)                                                                                                                      \
-              << "; " << #right << "=" << (right) << std::endl;                                                                        \
-    ASSERT(left operator right);                                                                                                       \
+#define ASSERT_EX(left, operator, right)                                                                             \
+  if (! ((left) operator (right))) {                                                                                 \
+    TRACE_AND_INDENT();                                                                                              \
+    std::cerr << "ASSERT FAILED: " << #left << " " << #operator << " " << #right                                     \
+              << " @ " << SRC_FILE_NAME << ":" << SRC_FUNC_NAME << " line " << SRC_LINE_NUM                          \
+              << " " << #left << "=" << (left)                                                                       \
+              << "; " << #right << "=" << (right) << std::endl;                                                      \
+    ASSERT(left operator right);                                                                                     \
   }
 #else
 #define ASSERT_EX(left, operator, right)

--- a/src/ptrcheck.cpp
+++ b/src/ptrcheck.cpp
@@ -134,11 +134,11 @@ void ERROR(const char *fmt, ...)
 }
 
 #define DIE(args...)                                                                                                 \
-  std::cerr << string_sprintf("Died at %s:%s line %u", __FILE__, __PRETTY_FUNCTION__, __LINE__);                     \
+  std::cerr << string_sprintf("Died at %s:%s line %u", SRC_FILE_NAME, SRC_FUNC_NAME, SRC_LINE_NUM);                  \
   CROAK(args);
 
 #define ERR(args...)                                                                                                 \
-  std::cerr << string_sprintf("Error at %s:%s line %u", __FILE__, __PRETTY_FUNCTION__, __LINE__);                    \
+  std::cerr << string_sprintf("Error at %s:%s line %u", SRC_FILE_NAME, SRC_FUNC_NAME, SRC_LINE_NUM);                 \
   ERROR(args);
 
 #endif


### PR DESCRIPTION
Another problem when compiling with MSVC is the use of `__PRETTY_FUNCTION__` macro, which is only available in GCC and Clang. I changed it to standardized `std::source_location`, which is portable across different compilers.

https://en.cppreference.com/w/cpp/utility/source_location