### PR TITLE
libstdc++v12 compile fixes

### DIFF
--- a/src/my_range.hpp
+++ b/src/my_range.hpp
@@ -3,7 +3,7 @@
 //
 
 #pragma once
-// REMOVED #include <algorithm>
+#include <algorithm> // for std::generate()
 #include <random>
 // REMOVED #include <vector>
 

--- a/src/my_template.hpp
+++ b/src/my_template.hpp
@@ -8,7 +8,7 @@
 
 // REMOVED #include "my_random.hpp"
 
-// REMOVED #include <algorithm>
+#include <algorithm> // for std::transform()
 #include <map>
 
 template < class T, template < typename ELEM, typename ALLOC = std::allocator< ELEM > > class C >

--- a/src/wid_botcon.cpp
+++ b/src/wid_botcon.cpp
@@ -12,6 +12,7 @@
 #include "my_wid.hpp"
 #include "my_wid_botcon.hpp"
 // REMOVED #include "slre.hpp"
+#include <algorithm> // for std::reverse()
 
 static void wid_botcon_wid_create(void);
 


### PR DESCRIPTION
I think you reverted previous compile fixes I did when you were cleaning up headers.  The latest libstdc++ that comes with gcc v12 (used by clang by default) is a lot more strict about including unnecessary headers.