### PR TITLE
python 3.12 warning fix & minor cleanup

### DIFF
--- a/build/ramdisk.py
+++ b/build/ramdisk.py
@@ -110,9 +110,7 @@ for record_number, (folder, filenames) in enumerate(sorted(files.items())):
         count += 1
 
         rec, orig_filename = filename
-        c_filename = orig_filename
-        c_filename = re.sub("-", "_", c_filename)
-        c_filename = re.sub("\.", "_", c_filename)
+        c_filename = re.sub(r'[\-\.]', "_", orig_filename)
         rel_path_filename = os.path.join(folder, orig_filename)
 
         with open("src/ramdisk_data_{}.S".format(ram_file), "a") as myfile:
@@ -151,9 +149,7 @@ with open("src/ramdisk_data.cpp", "w") as myfile:
             count += 1
 
             rec, orig_filename = filename
-            c_filename = orig_filename
-            c_filename = re.sub("-", "_", c_filename)
-            c_filename = re.sub("\.", "_", c_filename)
+            c_filename = re.sub(r'[\-\.]', "_", orig_filename)
             rel_path_filename = os.path.join(folder, orig_filename)
 
             myfile.write("    {\n")


### PR DESCRIPTION
found after my fedora 39 upgrade (which included newer python)

fixes these warnings:
.../build/ramdisk.py:115: SyntaxWarning: invalid escape sequence '\.'
  c_filename = re.sub("\.", "_", c_filename)
.../build/ramdisk.py:156: SyntaxWarning: invalid escape sequence '\.'
  c_filename = re.sub("\.", "_", c_filename)